### PR TITLE
New temperature dial colours - from blue to red - option 8 

### DIFF
--- a/Views/dashboard/js/widgets/dial.js
+++ b/Views/dashboard/js/widgets/dial.js
@@ -63,6 +63,11 @@
       offset = 0;
       segment = ["#a7cbe2","#68b7eb","#0d97f3","#0f81d0","#0c6dae","#08578e"];
     }
+    else if (type == 8)  //temperature dial blue-red, first segment blue should mean below freezing C
+    {
+      offset = 0;
+      segment = ["#b7beff","#ffd9d9","#ffbebe","#ff9c9c","#ff6e6e","#ff3d3d"];
+    }
 
 
 

--- a/Views/dashboard/js/widgets/dial.js
+++ b/Views/dashboard/js/widgets/dial.js
@@ -65,7 +65,7 @@
     }
     else if (type == 8)  //temperature dial blue-red, first segment blue should mean below freezing C
     {
-      offset = 0;
+      offset = -0.25;
       segment = ["#b7beff","#ffd9d9","#ffbebe","#ff9c9c","#ff6e6e","#ff3d3d"];
     }
 


### PR DESCRIPTION
General purpose temperature dial, the first segment (blue) could be reserved for when the temperature drops below zero degrees. 
