### PR TITLE
Add support for hosting behind HTTPS proxy

### DIFF
--- a/Models/process_model.php
+++ b/Models/process_model.php
@@ -153,7 +153,7 @@ function get_process_list()
 function auto_configure_inputs($userid, $id, $name)
 {
   // If a power or solar (power) feed
-  if (preg_match("/power/", $name) || preg_match("/solar/", $name))
+  if (preg_match("/power/i", $name) || preg_match("/solar/i", $name))
   {
     $feedid = create_feed($userid, $name, 1, 1);
     add_input_process($userid, $id, 1, $feedid);
@@ -165,7 +165,7 @@ function auto_configure_inputs($userid, $id, $name)
     add_input_process($userid, $id, 16, $feedid);
   }
 
-  if (preg_match("/temperature/", $name) || preg_match("/temp/", $name))
+  if (preg_match("/temperature/i", $name) || preg_match("/temp/i", $name))
   {
     // 1) log to feed
     $feedid = create_feed($userid, $name, 1, 1);

--- a/index.php
+++ b/index.php
@@ -23,13 +23,19 @@ require "Includes/core.inc.php";
 
 require_once "Includes/locale.php";
 
-// Thanks to seanwg for https addition
-$ssl = $_SERVER['HTTPS'];
-echo $ssl;
+// Default to http protocol
 $proto = "http";
-if ($ssl == "on") {
+
+// Detect if we are running HTTPS or proxied HTTPS
+if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
+	// Web server is running native HTTPS
 	$proto = "https";
 }
+elseif (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == "https") {
+	// Web server is running behind a proxy which is running HTTPS
+	$proto = "https";
+}
+
 $path = dirname("$proto://" . $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME']) . "/";
 
 require "Includes/db.php";


### PR DESCRIPTION
This adds support for the X_FORWARDED_PROTO which can be sent by proxies.

In my case I host a version of emoncms on my own server which is accessed from the internet via a https proxy:

internet --> [HTTPS] --> reverse proxy (nginx) --> [HTTP] --> emoncms (apache).

Without this header it is impossible for emoncms to detect that it should be returning https URLs.
